### PR TITLE
Add app upgrade policy API endpoint

### DIFF
--- a/netlify/functions/upgrade_policy.js
+++ b/netlify/functions/upgrade_policy.js
@@ -1,4 +1,5 @@
 import policy from '../helpers/upgrade_policy.json' with { type: 'json' };
+import { checkUpgrade } from '../helpers/upgrade_check.js';
 
 const HEADERS = {
   'Content-Type': 'application/json',
@@ -12,18 +13,6 @@ const createResponse = (statusCode, body = '') => ({
   headers: HEADERS,
   body: typeof body === 'string' ? body : JSON.stringify(body),
 });
-
-function compareVersions(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const na = pa[i] || 0;
-    const nb = pb[i] || 0;
-    if (na < nb) return -1;
-    if (na > nb) return 1;
-  }
-  return 0;
-}
 
 export const handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
@@ -40,38 +29,6 @@ export const handler = async (event) => {
     return createResponse(400, { error: 'Missing required query parameters: bundleId, currentVersion' });
   }
 
-  const app = policy.apps[bundleId];
-
-  if (!app) {
-    return createResponse(204);
-  }
-
-  const { minimumSupportedVersion, minimumRecommendedVersion, url } = app;
-
-  // Below minimum supported version → forced upgrade
-  if (minimumSupportedVersion && compareVersions(currentVersion, minimumSupportedVersion) < 0) {
-    return createResponse(200, {
-      type: 'forced',
-      title: 'Update Required',
-      message: 'This version is no longer supported. Please update to continue using the app.',
-      url,
-      minimumSupportedVersion,
-      minimumRecommendedVersion: minimumRecommendedVersion || null,
-    });
-  }
-
-  // Below minimum recommended version → suggested upgrade
-  if (minimumRecommendedVersion && compareVersions(currentVersion, minimumRecommendedVersion) < 0) {
-    return createResponse(200, {
-      type: 'suggested',
-      title: 'Update Available',
-      message: 'A new version is available with improvements and bug fixes.',
-      url,
-      minimumSupportedVersion: minimumSupportedVersion || null,
-      minimumRecommendedVersion,
-    });
-  }
-
-  // Current version is up to date
-  return createResponse(204);
+  const result = checkUpgrade(policy.apps[bundleId], currentVersion);
+  return result ? createResponse(200, result) : createResponse(204);
 };

--- a/netlify/functions/upgrade_policy.js
+++ b/netlify/functions/upgrade_policy.js
@@ -1,0 +1,81 @@
+import policy from '../helpers/upgrade_policy.json' with { type: 'json' };
+
+const HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+const createResponse = (statusCode, body = '') => ({
+  statusCode,
+  headers: HEADERS,
+  body: typeof body === 'string' ? body : JSON.stringify(body),
+});
+
+function compareVersions(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return createResponse(200);
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return createResponse(405, { error: 'Method not allowed' });
+  }
+
+  const { bundleId, currentVersion } = event.queryStringParameters || {};
+
+  if (!bundleId || !currentVersion) {
+    return createResponse(400, { error: 'Missing required query parameters: bundleId, currentVersion' });
+  }
+
+  const app = policy.apps[bundleId];
+
+  if (!app) {
+    return createResponse(200, { upgradeRequirement: null });
+  }
+
+  const { minimumSupportedVersion, minimumRecommendedVersion, appStoreUrl } = app;
+
+  // Below minimum supported version → forced upgrade
+  if (minimumSupportedVersion && compareVersions(currentVersion, minimumSupportedVersion) < 0) {
+    return createResponse(200, {
+      upgradeRequirement: {
+        type: 'forced',
+        title: 'Update Required',
+        message: 'This version is no longer supported. Please update to continue using the app.',
+        appStoreUrl,
+        minimumSupportedVersion,
+        minimumRecommendedVersion: minimumRecommendedVersion || null,
+      },
+    });
+  }
+
+  // Below minimum recommended version → suggested upgrade
+  if (minimumRecommendedVersion && compareVersions(currentVersion, minimumRecommendedVersion) < 0) {
+    return createResponse(200, {
+      upgradeRequirement: {
+        type: 'suggested',
+        title: 'Update Available',
+        message: 'A new version is available with improvements and bug fixes.',
+        appStoreUrl,
+        minimumSupportedVersion: minimumSupportedVersion || null,
+        minimumRecommendedVersion,
+      },
+    });
+  }
+
+  // Current version is up to date
+  return createResponse(200, { upgradeRequirement: null });
+};

--- a/netlify/functions/upgrade_policy.js
+++ b/netlify/functions/upgrade_policy.js
@@ -43,39 +43,35 @@ export const handler = async (event) => {
   const app = policy.apps[bundleId];
 
   if (!app) {
-    return createResponse(200, { upgradeRequirement: null });
+    return createResponse(204);
   }
 
-  const { minimumSupportedVersion, minimumRecommendedVersion, appStoreUrl } = app;
+  const { minimumSupportedVersion, minimumRecommendedVersion, url } = app;
 
   // Below minimum supported version → forced upgrade
   if (minimumSupportedVersion && compareVersions(currentVersion, minimumSupportedVersion) < 0) {
     return createResponse(200, {
-      upgradeRequirement: {
-        type: 'forced',
-        title: 'Update Required',
-        message: 'This version is no longer supported. Please update to continue using the app.',
-        appStoreUrl,
-        minimumSupportedVersion,
-        minimumRecommendedVersion: minimumRecommendedVersion || null,
-      },
+      type: 'forced',
+      title: 'Update Required',
+      message: 'This version is no longer supported. Please update to continue using the app.',
+      url,
+      minimumSupportedVersion,
+      minimumRecommendedVersion: minimumRecommendedVersion || null,
     });
   }
 
   // Below minimum recommended version → suggested upgrade
   if (minimumRecommendedVersion && compareVersions(currentVersion, minimumRecommendedVersion) < 0) {
     return createResponse(200, {
-      upgradeRequirement: {
-        type: 'suggested',
-        title: 'Update Available',
-        message: 'A new version is available with improvements and bug fixes.',
-        appStoreUrl,
-        minimumSupportedVersion: minimumSupportedVersion || null,
-        minimumRecommendedVersion,
-      },
+      type: 'suggested',
+      title: 'Update Available',
+      message: 'A new version is available with improvements and bug fixes.',
+      url,
+      minimumSupportedVersion: minimumSupportedVersion || null,
+      minimumRecommendedVersion,
     });
   }
 
   // Current version is up to date
-  return createResponse(200, { upgradeRequirement: null });
+  return createResponse(204);
 };

--- a/netlify/helpers/upgrade_check.js
+++ b/netlify/helpers/upgrade_check.js
@@ -1,0 +1,41 @@
+export function compareVersions(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
+}
+
+export function checkUpgrade(app, currentVersion) {
+  if (!app) return null;
+
+  const { minimumSupportedVersion, minimumRecommendedVersion, url } = app;
+
+  if (minimumSupportedVersion && compareVersions(currentVersion, minimumSupportedVersion) < 0) {
+    return {
+      type: 'forced',
+      title: 'Update Required',
+      message: 'This version is no longer supported. Please update to continue using the app.',
+      url,
+      minimumSupportedVersion,
+      minimumRecommendedVersion: minimumRecommendedVersion || null,
+    };
+  }
+
+  if (minimumRecommendedVersion && compareVersions(currentVersion, minimumRecommendedVersion) < 0) {
+    return {
+      type: 'suggested',
+      title: 'Update Available',
+      message: 'A new version is available with improvements and bug fixes.',
+      url,
+      minimumSupportedVersion: minimumSupportedVersion || null,
+      minimumRecommendedVersion,
+    };
+  }
+
+  return null;
+}

--- a/netlify/helpers/upgrade_policy.json
+++ b/netlify/helpers/upgrade_policy.json
@@ -1,16 +1,6 @@
 {
   "apps": {
-    "com.example.app1": {
-      "minimumSupportedVersion": "3.4.0",
-      "minimumRecommendedVersion": "3.8.0",
-      "url": "https://apps.apple.com/app/id1111111111"
-    },
-    "com.example.app2": {
-      "minimumSupportedVersion": "1.9.0",
-      "minimumRecommendedVersion": "2.3.0",
-      "url": "https://apps.apple.com/app/id2222222222"
-    },
-    "com.Math-Flash": {
+"com.Math-Flash": {
       "minimumRecommendedVersion": "2.4.0",
       "url": "https://apps.apple.com/app/id1449259588"
     },

--- a/netlify/helpers/upgrade_policy.json
+++ b/netlify/helpers/upgrade_policy.json
@@ -1,0 +1,22 @@
+{
+  "apps": {
+    "com.example.app1": {
+      "minimumSupportedVersion": "3.4.0",
+      "minimumRecommendedVersion": "3.8.0",
+      "appStoreUrl": "https://apps.apple.com/app/id1111111111"
+    },
+    "com.example.app2": {
+      "minimumSupportedVersion": "1.9.0",
+      "minimumRecommendedVersion": "2.3.0",
+      "appStoreUrl": "https://apps.apple.com/app/id2222222222"
+    },
+    "com.Math-Flash": {
+      "minimumRecommendedVersion": "2.4.0",
+      "appStoreUrl": "https://apps.apple.com/app/id1449259588"
+    },
+    "com.rspoon3.BankBonusTracker": {
+      "minimumRecommendedVersion": "1.1.0",
+      "appStoreUrl": "https://apps.apple.com/app/id6760981983"
+    }
+  }
+}

--- a/netlify/helpers/upgrade_policy.json
+++ b/netlify/helpers/upgrade_policy.json
@@ -3,20 +3,20 @@
     "com.example.app1": {
       "minimumSupportedVersion": "3.4.0",
       "minimumRecommendedVersion": "3.8.0",
-      "appStoreUrl": "https://apps.apple.com/app/id1111111111"
+      "url": "https://apps.apple.com/app/id1111111111"
     },
     "com.example.app2": {
       "minimumSupportedVersion": "1.9.0",
       "minimumRecommendedVersion": "2.3.0",
-      "appStoreUrl": "https://apps.apple.com/app/id2222222222"
+      "url": "https://apps.apple.com/app/id2222222222"
     },
     "com.Math-Flash": {
       "minimumRecommendedVersion": "2.4.0",
-      "appStoreUrl": "https://apps.apple.com/app/id1449259588"
+      "url": "https://apps.apple.com/app/id1449259588"
     },
     "com.rspoon3.BankBonusTracker": {
       "minimumRecommendedVersion": "1.1.0",
-      "appStoreUrl": "https://apps.apple.com/app/id6760981983"
+      "url": "https://apps.apple.com/app/id6760981983"
     }
   }
 }

--- a/netlify/tests/upgrade-policy.test.js
+++ b/netlify/tests/upgrade-policy.test.js
@@ -1,0 +1,128 @@
+import { compareVersions, checkUpgrade } from '../helpers/upgrade_check.js';
+import { handler } from '../functions/upgrade_policy.js';
+
+const makeEvent = (method, params = {}) => ({
+  httpMethod: method,
+  queryStringParameters: params,
+});
+
+const appWithBoth = {
+  minimumSupportedVersion: '2.0.0',
+  minimumRecommendedVersion: '3.0.0',
+  url: 'https://apps.apple.com/app/id123',
+};
+
+const appRecommendedOnly = {
+  minimumRecommendedVersion: '2.0.0',
+  url: 'https://apps.apple.com/app/id456',
+};
+
+describe('compareVersions', () => {
+  test('equal versions return 0', () => {
+    expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
+  });
+
+  test('less than returns -1', () => {
+    expect(compareVersions('1.0.0', '2.0.0')).toBe(-1);
+    expect(compareVersions('1.2.0', '1.3.0')).toBe(-1);
+    expect(compareVersions('1.2.3', '1.2.4')).toBe(-1);
+  });
+
+  test('greater than returns 1', () => {
+    expect(compareVersions('2.0.0', '1.0.0')).toBe(1);
+    expect(compareVersions('1.3.0', '1.2.0')).toBe(1);
+  });
+
+  test('handles different segment lengths', () => {
+    expect(compareVersions('2', '2.0.0')).toBe(0);
+    expect(compareVersions('1', '1.0.1')).toBe(-1);
+    expect(compareVersions('2.0.0', '2')).toBe(0);
+  });
+
+  test('handles year-based versions', () => {
+    expect(compareVersions('2021.3', '2025.4')).toBe(-1);
+    expect(compareVersions('2025.4', '2021.3')).toBe(1);
+    expect(compareVersions('2025.4', '2025.4')).toBe(0);
+    expect(compareVersions('2025.3', '2025.4')).toBe(-1);
+  });
+});
+
+describe('checkUpgrade', () => {
+  test('returns null for null app', () => {
+    expect(checkUpgrade(null, '1.0.0')).toBeNull();
+  });
+
+  test('returns null for undefined app', () => {
+    expect(checkUpgrade(undefined, '1.0.0')).toBeNull();
+  });
+
+  // Forced upgrade tests
+  test('returns forced when below minimumSupportedVersion', () => {
+    const result = checkUpgrade(appWithBoth, '1.0.0');
+    expect(result.type).toBe('forced');
+    expect(result.minimumSupportedVersion).toBe('2.0.0');
+    expect(result.minimumRecommendedVersion).toBe('3.0.0');
+  });
+
+  test('returns suggested when at minimumSupportedVersion but below recommended', () => {
+    const result = checkUpgrade(appWithBoth, '2.0.0');
+    expect(result.type).toBe('suggested');
+  });
+
+  test('returns null when at minimumRecommendedVersion', () => {
+    expect(checkUpgrade(appWithBoth, '3.0.0')).toBeNull();
+  });
+
+  test('returns null when above minimumRecommendedVersion', () => {
+    expect(checkUpgrade(appWithBoth, '4.0.0')).toBeNull();
+  });
+
+  // Recommended-only tests
+  test('returns suggested when below recommended (no supported set)', () => {
+    const result = checkUpgrade(appRecommendedOnly, '1.0.0');
+    expect(result.type).toBe('suggested');
+    expect(result.minimumSupportedVersion).toBeNull();
+  });
+
+  test('returns null when at recommended (no supported set)', () => {
+    expect(checkUpgrade(appRecommendedOnly, '2.0.0')).toBeNull();
+  });
+});
+
+describe('handler', () => {
+  test('returns 200 for OPTIONS', async () => {
+    const res = await handler(makeEvent('OPTIONS'));
+    expect(res.statusCode).toBe(200);
+  });
+
+  test('returns 405 for POST', async () => {
+    const res = await handler(makeEvent('POST'));
+    expect(res.statusCode).toBe(405);
+  });
+
+  test('returns 400 when bundleId is missing', async () => {
+    const res = await handler(makeEvent('GET', { currentVersion: '1.0.0' }));
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('returns 400 when currentVersion is missing', async () => {
+    const res = await handler(makeEvent('GET', { bundleId: 'com.Math-Flash' }));
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('returns 204 for unknown bundle ID', async () => {
+    const res = await handler(makeEvent('GET', { bundleId: 'com.unknown', currentVersion: '1.0.0' }));
+    expect(res.statusCode).toBe(204);
+  });
+
+  test('returns suggested for Math Flash below recommended', async () => {
+    const res = await handler(makeEvent('GET', { bundleId: 'com.Math-Flash', currentVersion: '2.0.0' }));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).type).toBe('suggested');
+  });
+
+  test('returns 204 for Math Flash at recommended', async () => {
+    const res = await handler(makeEvent('GET', { bundleId: 'com.Math-Flash', currentVersion: '2.4.0' }));
+    expect(res.statusCode).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary
- New Netlify function (`/api/upgrade_policy`) that returns upgrade requirements based on bundle ID and current app version
- Compares versions against a JSON config to determine if an upgrade is forced, suggested, or not needed
- Configured for Math Flash (recommended 2.4.0) and BankBonusTracker (recommended 1.1.0) with placeholder example apps

## Test plan
- [ ] `GET /api/upgrade_policy?bundleId=com.Math-Flash&currentVersion=2.0.0` returns `suggested` upgrade
- [ ] `GET /api/upgrade_policy?bundleId=com.Math-Flash&currentVersion=2.4.0` returns `null` upgradeRequirement
- [ ] `GET /api/upgrade_policy?bundleId=unknown.app&currentVersion=1.0.0` returns `null` upgradeRequirement
- [ ] Missing query params returns 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)